### PR TITLE
update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,8 @@ tsc deploy.ts
 node deploy.js
 ```
 
-You could also just do `ts-node deploy.ts`.
+You could also just do `npx ts-node deploy.ts` if you are using npm.
+For yarn use `yarn ts-node deploy.ts`.
 
 ### Deploying to a testnet
 


### PR DESCRIPTION
if we use `ts-node deploy.ts` and you don't have ts-node installed globally it gives error command not found, instead we can use `npx ts-node deploy.ts` or `yarn ts-node deploy.ts`, because we have installed ts-node in our repo and it should now work