### PR TITLE
Corrected favourite spelling

### DIFF
--- a/SimpleStorage.sol
+++ b/SimpleStorage.sol
@@ -7,27 +7,28 @@ pragma solidity 0.8.7;
 // pragma solidity >=0.8.0 <0.9.0;
 
 contract SimpleStorage {
-    uint256 favoriteNumber;
+    uint256 favouriteNumber;
 
     struct People {
-        uint256 favoriteNumber;
+        uint256 favouriteNumber;
         string name;
     }
+
     // uint256[] public anArray;
     People[] public people;
 
-    mapping(string => uint256) public nameToFavoriteNumber;
+    mapping(string => uint256) public nameToFavouriteNumber;
 
-    function store(uint256 _favoriteNumber) public {
-        favoriteNumber = _favoriteNumber;
+    function store(uint256 _favouriteNumber) public {
+        favouriteNumber = _favouriteNumber;
     }
 
     function retrieve() public view returns (uint256) {
-        return favoriteNumber;
+        return favouriteNumber;
     }
 
-    function addPerson(string memory _name, uint256 _favoriteNumber) public {
-        people.push(People(_favoriteNumber, _name));
-        nameToFavoriteNumber[_name] = _favoriteNumber;
+    function addPerson(string memory _name, uint256 _favouriteNumber) public {
+        people.push(People(_favouriteNumber, _name));
+        nameToFavouriteNumber[_name] = _favouriteNumber;
     }
 }


### PR DESCRIPTION
Corrected favourite spelling, from "favorite" to "favourite".