### PR TITLE
Removed console log of private key and password

### DIFF
--- a/encryptKey.js
+++ b/encryptKey.js
@@ -3,8 +3,6 @@ const fs = require("fs-extra")
 require("dotenv").config()
 
 async function main() {
-    console.log(process.env.PRIVATE_KEY)
-    console.log(process.env.PRIVATE_KEY_PASSWORD)
     const wallet = new ethers.Wallet(process.env.PRIVATE_KEY)
     const encryptedJsonKey = await wallet.encrypt(
         process.env.PRIVATE_KEY_PASSWORD,


### PR DESCRIPTION
We can console log the process.env.PRIVATE_KEY and process.env.PRIVATE_KEY_PASSWORD during development, but we don't want to expose the private key and password in the final code. Removed the two console log statements. However, it's still OK to console log the encrypted JSON key.