### PR TITLE
Some usage changes in ethers6 version

### DIFF
--- a/deploy.js
+++ b/deploy.js
@@ -6,6 +6,8 @@ require("dotenv").config()
 async function main() {
     // First, compile this!
     // And make sure to have your ganache network up!
+    // The old way can be seen below:
+    // let provider = new ethers.providers.JsonRpcProvider(process.env.RPC_URL)
     // On ether 6 and above, you should use like this
     let provider = new ethers.JsonRpcProvider(process.env.RPC_URL)
     // let provider = new ethers.providers.JsonRpcProvider(process.env.RPC_URL)

--- a/deploy.js
+++ b/deploy.js
@@ -6,7 +6,9 @@ require("dotenv").config()
 async function main() {
     // First, compile this!
     // And make sure to have your ganache network up!
-    let provider = new ethers.providers.JsonRpcProvider(process.env.RPC_URL)
+    // On ether 6 and above, you should use like this
+    let provider = new ethers.JsonRpcProvider(process.env.RPC_URL)
+    // let provider = new ethers.providers.JsonRpcProvider(process.env.RPC_URL)
     let wallet = new ethers.Wallet(process.env.PRIVATE_KEY, provider)
     // const encryptedJson = fs.readFileSync("./.encryptedKey.json", "utf8");
     // let wallet = new ethers.Wallet.fromEncryptedJsonSync(

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "dependencies": {
     "dotenv": "^14.2.0",
-    "ethers": "^5.5.3",
+    "ethers": "^6.2.3",
     "prettier": "^2.5.1",
     "solc": "0.8.7-fixed"
   },


### PR DESCRIPTION
Since ethers has been updated to version 6, the usage of JsonRpcProvider has undergone some changes, which has brought a lot of confusion to many friends who have recently started learning 